### PR TITLE
Compile miasm expr to python lambdas for significantly faster evaluation

### DIFF
--- a/msynth/simplification/oracle.py
+++ b/msynth/simplification/oracle.py
@@ -1,19 +1,169 @@
-import functools
 import hashlib
 import multiprocessing
-import os
 import pickle
 import re
+import warnings
 from pathlib import Path
-from typing import Dict, Iterator, List, Set, Tuple
+from typing import Callable, Dict, Iterator, List, Set, Tuple
 
-from miasm.expression.expression import Expr, ExprId, ExprInt, ExprOp, ExprSlice
+from miasm.expression.expression import Expr, ExprCond, ExprId, ExprInt, ExprOp, ExprSlice, ExprCompose
 from miasm.expression.simplifications import expr_simp
 
 from msynth.simplification.ast import AbstractSyntaxTreeTranslator
 from msynth.utils.expr_utils import get_unique_variables
 from msynth.utils.sampling import gen_inputs
 
+
+
+def compile_expr(expr: Expr) -> Callable[[List[int]], int]:
+    """
+    Compile a miasm expression to Python function.
+
+    Instead of walking the expression tree for each evaluation,
+    this compiles to a Python lambda that does direct arithmetic.
+
+    Args:
+        expr: Miasm expression to compile.
+
+    Returns:
+        A function that takes an inputs array and returns the result.
+    """
+    mask = (1 << expr.size) - 1
+
+    def sign_ext(val: str, size: int) -> str:
+        sign_bit = 1 << (size - 1)
+        return f"(({val}^{sign_bit})-{sign_bit})"
+
+    def compile_node(e: Expr) -> str:
+        if isinstance(e, ExprInt):
+            return str(int(e))
+
+        elif isinstance(e, ExprId):
+            name = e.name
+            if name.startswith("p") and name[1:].isdigit():
+                idx = int(name[1:])
+                var_mask = (1 << e.size) - 1 # Mask input to variable's declared size
+                return f"(i[{idx}]&{var_mask})"
+            else:
+                raise ValueError(f"Unknown variable: {name}")
+
+        elif isinstance(e, ExprOp):
+            op = e.op
+            args = e.args
+            op_mask = (1 << e.size) - 1 # Mask for this operation's result size
+
+            if len(args) == 1:
+                a = compile_node(args[0])
+                if op == "-":
+                    return f"((-{a})&{op_mask})"
+                elif op == "parity":
+                    # x86 parity: 1 if even number of bits in low 8 bits, 0 if odd
+                    return f"((bin(({a})&0xFF).count('1')+1)&1)"
+                elif op == "cnttrailzeros":
+                    size = e.size
+                    return f"(({a}&-{a}).bit_length()-1 if {a} else {size})"
+                elif op == "cntleadzeros":
+                    size = e.size
+                    return f"({size}-{a}.bit_length() if {a} else {size})"
+                else:
+                    raise ValueError(f"Unknown unary op: {op}")
+
+            elif op in ["+", "*", "&", "|", "^"] and len(args) >= 2:
+                compiled_args = [compile_node(arg) for arg in args]
+                py_op = op
+                result = py_op.join(compiled_args)
+                return f"(({result})&{op_mask})"
+
+            elif len(args) == 2:
+                a, b = compile_node(args[0]), compile_node(args[1])
+                if op == "-":
+                    return f"(({a}-{b})&{op_mask})"
+                elif op == ">>":
+                    size = e.size
+                    return f"((({a})>>({b})&{op_mask}) if ({b})<{size} else 0)"
+                elif op == "<<":
+                    size = e.size
+                    return f"((({a})<<({b})&{op_mask}) if ({b})<{size} else 0)"
+                elif op == "a>>":
+                    size = e.size
+                    sign_bit = 1 << (size - 1)
+                    sa = sign_ext(a, size)
+                    # Sign extend, then shift; if shift >= size, result is all 1s or 0s based on sign
+                    return f"(({sa}>>({b})&{op_mask}) if ({b})<{size} else ({op_mask} if ({a})&{sign_bit} else 0))"
+                elif op == "/":
+                    return f"(({a}//{b})&{op_mask} if {b} else 0)"
+                elif op == "%":
+                    return f"(({a}%{b})&{op_mask} if {b} else 0)"
+                elif op == "==":
+                    return f"(1 if {a}=={b} else 0)"
+                elif op == "<u":
+                    return f"(1 if {a}<{b} else 0)"
+                elif op == "<=u":
+                    return f"(1 if {a}<={b} else 0)"
+                elif op == "<s":
+                    size = e.args[0].size
+                    return f"(1 if {sign_ext(a, size)}<{sign_ext(b, size)} else 0)"
+                elif op == "<=s":
+                    size = e.args[0].size
+                    return f"(1 if {sign_ext(a, size)}<={sign_ext(b, size)} else 0)"
+                elif op == "<<<":
+                    # Rotate left: (x << n) | (x >> (size - n))
+                    size = e.size
+                    return f"(((({a})<<(({b})%{size}))|(({a})>>(({size}-({b})%{size})%{size})))&{op_mask})"
+                elif op == ">>>":
+                    # Rotate right: (x >> n) | (x << (size - n))
+                    size = e.size
+                    return f"(((({a})>>(({b})%{size}))|(({a})<<(({size}-({b})%{size})%{size})))&{op_mask})"
+                elif op == "udiv":
+                    return f"(({a}//{b})&{op_mask} if {b} else 0)"
+                elif op == "umod":
+                    return f"(({a}%{b})&{op_mask} if {b} else 0)"
+                elif op == "sdiv":
+                    size = e.args[0].size
+                    sa, sb = sign_ext(a, size), sign_ext(b, size)
+                    return f"((int({sa}//{sb}) if {sb}>0 else -int({sa}//-{sb}) if {sb}<0 else 0)&{op_mask} if {b} else 0)"
+                elif op == "smod":
+                    # Result has same sign as dividend: a - trunc(a/b) * b
+                    size = e.args[0].size
+                    sa, sb = sign_ext(a, size), sign_ext(b, size)
+                    return f"(({sa}-int({sa}/{sb})*{sb})&{op_mask} if {b} else 0)"
+                elif op == "**":
+                    return f"(({a}**{b})&{op_mask})"
+                else:
+                    raise ValueError(f"Unknown binary op: {op}")
+            else:
+                raise ValueError(f"Unexpected arity {len(args)} for op {op}")
+
+        elif isinstance(e, ExprSlice):
+            arg = compile_node(e.arg)
+            start, stop = e.start, e.stop
+            slice_mask = (1 << (stop - start)) - 1
+            return f"(({arg}>>{start})&{slice_mask})"
+
+        elif isinstance(e, ExprCond):
+            cond = compile_node(e.cond)
+            src1 = compile_node(e.src1)
+            src2 = compile_node(e.src2)
+            return f"({src1} if {cond} else {src2})"
+
+        elif isinstance(e, ExprCompose):
+            result_parts = []
+            offset = 0
+            for arg in e.args:
+                part = compile_node(arg)
+                if offset == 0:
+                    result_parts.append(f"({part})")
+                else:
+                    result_parts.append(f"(({part})<<{offset})")
+                offset += arg.size
+            return "(" + "|".join(result_parts) + ")"
+
+        else:
+            raise ValueError(f"Unknown expression type: {type(e).__name__}")
+
+    code = compile_node(expr)
+    func_code = f"lambda i:({code})&{mask}"
+    return eval(func_code)
 
 def calc_hash(s: str) -> str:
     """
@@ -84,9 +234,13 @@ class SimplificationOracle(object):
         Returns:
             List of ints, representing the expression' output behavior.
         """
-        outputs = [SimplificationOracle.evaluate_expression(expr, input_array)
-                   for input_array in self.inputs]
-        return outputs
+        try:
+            func = compile_expr(expr)
+            return [func(input_array) for input_array in self.inputs]
+        except ValueError as e:
+            # Fallback to slower tree-walking evaluation for unsupported expression types
+            warnings.warn(f"compile_expr fallback: {e} - consider adding support in compile_expr()")
+            return [self.evaluate_expression(expr, input_array) for input_array in self.inputs]
 
     @staticmethod
     def parse_library(library_path: Path) -> Iterator[str]:

--- a/msynth/simplification/oracle.py
+++ b/msynth/simplification/oracle.py
@@ -4,178 +4,16 @@ import pickle
 import re
 import warnings
 from pathlib import Path
-from typing import Callable, Dict, Iterator, List, Set, Tuple
+from typing import Dict, Iterator, List, Set, Tuple
 
-from miasm.expression.expression import Expr, ExprCond, ExprId, ExprInt, ExprOp, ExprSlice, ExprCompose
+from miasm.expression.expression import Expr, ExprId, ExprInt, ExprOp, ExprSlice
 from miasm.expression.simplifications import expr_simp
 
 from msynth.simplification.ast import AbstractSyntaxTreeTranslator
 from msynth.utils.expr_utils import get_unique_variables
 from msynth.utils.sampling import gen_inputs
+from msynth.utils.expr_utils import compile_expr_to_python
 
-
-
-def compile_expr(expr: Expr) -> Callable[[List[int]], int]:
-    """
-    Compile a miasm expression to Python function.
-
-    Instead of walking the expression tree for each evaluation,
-    this compiles to a Python lambda that does direct arithmetic.
-
-    Args:
-        expr: Miasm expression to compile.
-
-    Returns:
-        A function that takes an inputs array and returns the result.
-    """
-    mask = (1 << expr.size) - 1
-
-    def sign_ext(val: str, size: int) -> str:
-        sign_bit = 1 << (size - 1)
-        return f"(({val}^{sign_bit})-{sign_bit})"
-
-    def compile_node(e: Expr) -> str:
-        if isinstance(e, ExprInt):
-            return str(int(e))
-
-        elif isinstance(e, ExprId):
-            name = e.name
-            if name.startswith("p") and name[1:].isdigit():
-                idx = int(name[1:])
-                var_mask = (1 << e.size) - 1 # Mask input to variable's declared size
-                return f"(i[{idx}]&{var_mask})"
-            else:
-                raise ValueError(f"Unknown variable: {name}")
-
-        elif isinstance(e, ExprOp):
-            op = e.op
-            args = e.args
-            op_mask = (1 << e.size) - 1 # Mask for this operation's result size
-
-            if len(args) == 1:
-                a = compile_node(args[0])
-                if op == "-":
-                    return f"((-{a})&{op_mask})"
-                elif op == "parity":
-                    # x86 parity: 1 if even number of bits in low 8 bits, 0 if odd
-                    return f"((bin(({a})&0xFF).count('1')+1)&1)"
-                elif op == "cnttrailzeros":
-                    size = e.size
-                    return f"(({a}&-{a}).bit_length()-1 if {a} else {size})"
-                elif op == "cntleadzeros":
-                    size = e.size
-                    return f"({size}-({a}).bit_length() if {a} else {size})"
-                elif (m := re.fullmatch(r"zeroExt_(\d+)", op)):
-                    target_size = int(m.group(1))
-                    target_mask = (1 << target_size) - 1
-                    return f"(({a})&{target_mask})"
-                elif (m := re.fullmatch(r"signExt_(\d+)", op)):
-                    target_size = int(m.group(1))
-                    source_size = args[0].size
-                    target_mask = (1 << target_size) - 1
-                    sign_bit = 1 << (source_size - 1)
-                    # If sign bit is set, extend with 1s; otherwise keep as-is
-                    extension_bits = ((1 << target_size) - 1) ^ ((1 << source_size) - 1)
-                    return f"((({a})|{extension_bits})&{target_mask} if ({a})&{sign_bit} else ({a})&{target_mask})"
-                else:
-                    raise ValueError(f"Unknown unary op: {op}")
-
-            elif op in ["+", "*", "&", "|", "^"] and len(args) >= 2:
-                compiled_args = [compile_node(arg) for arg in args]
-                py_op = op
-                result = py_op.join(compiled_args)
-                return f"(({result})&{op_mask})"
-
-            elif len(args) == 2:
-                a, b = compile_node(args[0]), compile_node(args[1])
-                if op == "-":
-                    return f"(({a}-{b})&{op_mask})"
-                elif op == ">>":
-                    size = e.size
-                    return f"((({a})>>({b})&{op_mask}) if ({b})<{size} else 0)"
-                elif op == "<<":
-                    size = e.size
-                    return f"((({a})<<({b})&{op_mask}) if ({b})<{size} else 0)"
-                elif op == "a>>":
-                    size = e.size
-                    sign_bit = 1 << (size - 1)
-                    sa = sign_ext(a, size)
-                    # Sign extend, then shift; if shift >= size, result is all 1s or 0s based on sign
-                    return f"(({sa}>>({b})&{op_mask}) if ({b})<{size} else ({op_mask} if ({a})&{sign_bit} else 0))"
-                elif op == "/":
-                    return f"(({a}//{b})&{op_mask} if {b} else 0)"
-                elif op == "%":
-                    return f"(({a}%{b})&{op_mask} if {b} else 0)"
-                elif op == "==":
-                    return f"(1 if {a}=={b} else 0)"
-                elif op == "<u":
-                    return f"(1 if {a}<{b} else 0)"
-                elif op == "<=u":
-                    return f"(1 if {a}<={b} else 0)"
-                elif op == "<s":
-                    size = e.args[0].size
-                    return f"(1 if {sign_ext(a, size)}<{sign_ext(b, size)} else 0)"
-                elif op == "<=s":
-                    size = e.args[0].size
-                    return f"(1 if {sign_ext(a, size)}<={sign_ext(b, size)} else 0)"
-                elif op == "<<<":
-                    # Rotate left: (x << n) | (x >> (size - n))
-                    size = e.size
-                    return f"(((({a})<<(({b})%{size}))|(({a})>>(({size}-({b})%{size})%{size})))&{op_mask})"
-                elif op == ">>>":
-                    # Rotate right: (x >> n) | (x << (size - n))
-                    size = e.size
-                    return f"(((({a})>>(({b})%{size}))|(({a})<<(({size}-({b})%{size})%{size})))&{op_mask})"
-                elif op == "udiv":
-                    return f"(({a}//{b})&{op_mask} if {b} else 0)"
-                elif op == "umod":
-                    return f"(({a}%{b})&{op_mask} if {b} else 0)"
-                elif op == "sdiv":
-                    size = e.args[0].size
-                    sa, sb = sign_ext(a, size), sign_ext(b, size)
-                    return f"(int({sa}/{sb})&{op_mask} if {b} else 0)"
-                elif op == "smod":
-                    # Result has same sign as dividend: a - trunc(a/b) * b
-                    size = e.args[0].size
-                    sa, sb = sign_ext(a, size), sign_ext(b, size)
-                    return f"(({sa}-int({sa}/{sb})*{sb})&{op_mask} if {b} else 0)"
-                elif op == "**":
-                    return f"(({a}**{b})&{op_mask})"
-                else:
-                    raise ValueError(f"Unknown binary op: {op}")
-            else:
-                raise ValueError(f"Unexpected arity {len(args)} for op {op}")
-
-        elif isinstance(e, ExprSlice):
-            arg = compile_node(e.arg)
-            start, stop = e.start, e.stop
-            slice_mask = (1 << (stop - start)) - 1
-            return f"(({arg}>>{start})&{slice_mask})"
-
-        elif isinstance(e, ExprCond):
-            cond = compile_node(e.cond)
-            src1 = compile_node(e.src1)
-            src2 = compile_node(e.src2)
-            return f"({src1} if {cond} else {src2})"
-
-        elif isinstance(e, ExprCompose):
-            result_parts = []
-            offset = 0
-            for arg in e.args:
-                part = compile_node(arg)
-                if offset == 0:
-                    result_parts.append(f"({part})")
-                else:
-                    result_parts.append(f"(({part})<<{offset})")
-                offset += arg.size
-            return "(" + "|".join(result_parts) + ")"
-
-        else:
-            raise ValueError(f"Unknown expression type: {type(e).__name__}")
-
-    code = compile_node(expr)
-    func_code = f"lambda i:({code})&{mask}"
-    return eval(func_code)
 
 def calc_hash(s: str) -> str:
     """
@@ -247,7 +85,7 @@ class SimplificationOracle(object):
             List of ints, representing the expression' output behavior.
         """
         try:
-            func = compile_expr(expr)
+            func = compile_expr_to_python(expr)
             return [func(input_array) for input_array in self.inputs]
         except ValueError as e:
             # Fallback to slower tree-walking evaluation for unsupported expression types


### PR DESCRIPTION
Currently `gen_oracle.py` on `3_variables_constants_7_nodes.txt` doesn't even complete on my system. It runs for several minutes and then gets killed for OOM, so I don't have a specific number to compare to. With this change, I can successfully generate a new oracle with the default configuration in about 50 seconds.

I've spot checked evaluation is correct with the script below:

<details>

```python

#!/usr/bin/env python3
#scripts/test_compile_expr.py

import sys

from miasm.expression.expression import ExprId, ExprInt, ExprOp, ExprSlice, ExprCond, ExprCompose
from msynth.simplification.oracle import compile_expr, SimplificationOracle

TEST_VALUES = {
    8: [0, 1, 2, 127, 128, 255, 0x55, 0xAA],
    16: [0, 1, 2, 255, 256, 0x7FFF, 0x8000, 0xFFFF, 0x5555, 0xAAAA],
    32: [0, 1, 2, 0xFF, 0x100, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF, 0x55555555, 0xAAAAAAAA],
    64: [0, 1, 2, 0xFF, 0x7FFFFFFFFFFFFFFF, 0x8000000000000000, 0xFFFFFFFFFFFFFFFF],
}

SHIFT_VALUES = [0, 1, 7, 8, 15, 16, 31, 32, 63]

def test_expr(expr, inputs_list, size):
    func = compile_expr(expr)

    for inputs in inputs_list:
        compiled_result = func(inputs)

        miasm_result = SimplificationOracle.evaluate_expression(expr, inputs)

        mask = (1 << size) - 1
        compiled_result &= mask
        miasm_result &= mask

        if compiled_result != miasm_result:
            print(f"  MISMATCH: {expr}")
            print(f"    inputs: {inputs}")
            print(f"    compiled: {compiled_result:#x}")
            print(f"    miasm:    {miasm_result:#x}")

def gen_inputs(num_vars, values):
    if num_vars == 0:
        return [[]]
    if num_vars == 1:
        return [[v] for v in values]
    if num_vars == 2:
        return [[a, b] for a in values for b in values[:4]]
    return [[a, b, c] for a in values[:3] for b in values[:3] for c in values[:3]]


def main():
    for size in [16, 32, 64]:
        values = TEST_VALUES[size]
        mask = (1 << size) - 1

        for v in values:
            expr = ExprInt(v & mask, size)
            test_expr(expr, [[]], size)

        for i in range(2):
            expr = ExprId(f"p{i}", size)
            test_expr(expr, gen_inputs(i + 1, values), size)

        unary_ops = ["-", "parity", "cnttrailzeros", "cntleadzeros"]
        p0 = ExprId("p0", size)
        for op in unary_ops:
            expr = ExprOp(op, p0)
            test_expr(expr, gen_inputs(1, values), size)

        arith_ops = ["+", "-", "*", "^", "&", "|"]
        p0 = ExprId("p0", size)
        p1 = ExprId("p1", size)
        for op in arith_ops:
            expr = ExprOp(op, p0, p1)
            test_expr(expr, gen_inputs(2, values), size)

        shift_ops = [">>", "<<", "a>>"]
        for op in shift_ops:
            expr = ExprOp(op, p0, p1)
            shift_inputs = [[v, s] for v in values for s in SHIFT_VALUES if s < size * 2]
            test_expr(expr, shift_inputs, size)

        rotate_ops = ["<<<", ">>>"]
        for op in rotate_ops:
            expr = ExprOp(op, p0, p1)
            rotate_inputs = [[v, s] for v in values for s in SHIFT_VALUES if s < size * 2]
            test_expr(expr, rotate_inputs, size)

        div_ops = ["/", "%", "udiv", "umod", "sdiv", "smod"]
        for op in div_ops:
            expr = ExprOp(op, p0, p1)
            div_inputs = [[a, b] for a in values for b in values if b != 0][:20]
            test_expr(expr, div_inputs, size)

        cmp_ops = ["==", "<u", "<=u", "<s", "<=s"]
        for op in cmp_ops:
            expr = ExprOp(op, p0, p1)
            test_expr(expr, gen_inputs(2, values), size)

        expr = ExprOp("**", p0, p1)
        pow_inputs = [[a, b] for a in [0, 1, 2, 3] for b in [0, 1, 2, 3, 4]]
        test_expr(expr, pow_inputs, size)

        for start, stop in [(0, 8), (8, 16), (0, size//2), (size//4, size//2)]:
            if stop <= size:
                expr = ExprSlice(p0, start, stop)
                test_expr(expr, gen_inputs(1, values), stop - start)

        cond = ExprOp("==", ExprId("p0", size), ExprInt(0, size))
        expr = ExprCond(cond, ExprId("p1", size), ExprId("p2", size))
        test_expr(expr, gen_inputs(3, values[:4]), size)

        if size >= 16:
            half = size // 2
            lo = ExprId("p0", half)
            hi = ExprId("p1", half)
            expr = ExprCompose(lo, hi)
            half_values = TEST_VALUES.get(half, TEST_VALUES[16])
            test_expr(expr, gen_inputs(2, half_values), size)

if __name__ == "__main__":
    sys.exit(main())
```
</details>