### PR TITLE
Greatly reduce oracle loading times by using sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ msynth - INFO: Done in 632.84 seconds
 
 Depending on the size of the pre-computed simplification database, this may take a few minutes or hours, depending on your computer. Alternatively, you can use the pre-computed [oracle.pickle](/oracle.pickle).
 
+Optionally, the `--sqlite` flag can be used to generate the oracle in SQLite format, which enables lazy loading and significantly faster startup times:
+
+```
+$ python scripts/gen_oracle.py database/3_variables_constants_7_nodes.txt oracle.db --sqlite
+```
+
 Afterward, the serialized oracle can be used to simplify complex expressions:
 
 ```python

--- a/msynth/simplification/oracle.py
+++ b/msynth/simplification/oracle.py
@@ -6,13 +6,12 @@ import warnings
 from pathlib import Path
 from typing import Dict, Iterator, List, Set, Tuple
 
-from miasm.expression.expression import Expr, ExprId, ExprInt, ExprOp, ExprSlice
+from miasm.expression.expression import Expr, ExprInt
 from miasm.expression.simplifications import expr_simp
 
 from msynth.simplification.ast import AbstractSyntaxTreeTranslator
-from msynth.utils.expr_utils import get_unique_variables
+from msynth.utils.expr_utils import get_unique_variables, compile_expr_to_python, parse_expr
 from msynth.utils.sampling import gen_inputs
-from msynth.utils.expr_utils import compile_expr_to_python
 
 
 def calc_hash(s: str) -> str:
@@ -171,7 +170,7 @@ class SimplificationOracle(object):
         # init AST translator
         translator = AbstractSyntaxTreeTranslator()
         # read expression
-        expr = eval(expr_str)
+        expr = parse_expr(expr_str)
         # simplify and transform into abtsract syntax tree
         expr = translator.from_expr(expr_simp(expr))
         # calculate output behavior

--- a/msynth/simplification/simplifier.py
+++ b/msynth/simplification/simplifier.py
@@ -155,8 +155,8 @@ class Simplifier:
 
         # if all evaluate to same constant, add/replace equiv class with constant
         if len(set(outputs)) == 1:
-            self.oracle.oracle_map[equiv_class] = [ExprInt(
-                outputs[0], expr.size)]
+            self.oracle.set_equiv_class(equiv_class, [ExprInt(
+                outputs[0], expr.size)])
 
         return equiv_class
 

--- a/msynth/utils/expr_utils.py
+++ b/msynth/utils/expr_utils.py
@@ -1,6 +1,34 @@
 import re
 from typing import Callable, List, Dict
-from miasm.expression.expression import Expr, ExprCond, ExprId, ExprInt, ExprOp, ExprSlice, ExprCompose
+from miasm.expression.expression import Expr, ExprInt, ExprId, ExprSlice, ExprMem, \
+    ExprCond, ExprCompose, ExprOp, ExprAssign, ExprLoc, LocKey
+
+def parse_expr(expr_str: str) -> Expr:
+    """
+    Parse a miasm expression from its repr string.
+
+    Note: miasm.expression.parser.str_to_expr exists but is slower.
+
+    Args:
+        expr_str: String representation of a miasm expression (e.g. from repr()).
+
+    Returns:
+        Parsed Expr object.
+    """
+    globals = {
+        "ExprId": ExprId,
+        "ExprOp": ExprOp,
+        "ExprInt": ExprInt,
+        "ExprSlice": ExprSlice,
+        "ExprCond": ExprCond,
+        "ExprCompose": ExprCompose,
+        "ExprMem": ExprMem,
+        "ExprAssign": ExprAssign,
+        "ExprLoc": ExprLoc,
+        "LocKey": LocKey,
+    }
+    return eval(expr_str, globals)
+
 
 def gen_unification_dict(expr: Expr) -> Dict[Expr, Expr]:
     """

--- a/msynth/utils/sqlite.py
+++ b/msynth/utils/sqlite.py
@@ -1,0 +1,140 @@
+import pickle
+import sqlite3
+import zlib
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Tuple
+
+from miasm.expression.expression import Expr
+from msynth.utils.expr_utils import parse_expr
+
+
+class NotSqliteOracleError(Exception):
+    """Raised when a file is not a valid sqlite oracle database."""
+    pass
+
+
+class SqliteOracleMap:
+    """Dict-like lazy-loading proxy for sqlite oracle storage.
+
+    Key hashes are stored as 20 byte binary BLOBs.
+    Members are stored as zlib-compressed newline-separated repr strings.
+    """
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    @staticmethod
+    def _to_bin(hex_key: str) -> bytes:
+        """Convert hex string key to binary for storage."""
+        return bytes.fromhex(hex_key)
+
+    @staticmethod
+    def _to_hex(bin_key: bytes) -> str:
+        """Convert binary key back to hex string."""
+        return bin_key.hex()
+
+    @staticmethod
+    def _exprs_to_bytes(exprs: List[Expr]) -> bytes:
+        """Serialize list of expressions as compressed repr strings."""
+        text = '\n'.join(repr(e) for e in exprs)
+        return zlib.compress(text.encode(), level=9)
+
+    @staticmethod
+    def _bytes_to_exprs(data: bytes) -> List[Expr]:
+        """Deserialize compressed repr strings back to expressions."""
+        text = zlib.decompress(data).decode()
+        return [parse_expr(line) for line in text.split('\n') if line]
+
+    def __contains__(self, key: str) -> bool:
+        cur = self._conn.execute(
+            "SELECT 1 FROM equiv_classes WHERE equiv_class = ?",
+            (self._to_bin(key),))
+        return cur.fetchone() is not None
+
+    def __getitem__(self, key: str) -> List[Expr]:
+        cur = self._conn.execute(
+            "SELECT members FROM equiv_classes WHERE equiv_class = ?",
+            (self._to_bin(key),))
+        row = cur.fetchone()
+        if row is None:
+            raise KeyError(key)
+        return self._bytes_to_exprs(row[0])
+
+    def keys(self) -> Iterator[str]:
+        cur = self._conn.execute("SELECT equiv_class FROM equiv_classes")
+        return (self._to_hex(row[0]) for row in cur)
+
+    def items(self) -> Iterator[Tuple[str, List[Expr]]]:
+        cur = self._conn.execute("SELECT equiv_class, members FROM equiv_classes")
+        for row in cur:
+            yield self._to_hex(row[0]), self._bytes_to_exprs(row[1])
+
+    def __len__(self) -> int:
+        cur = self._conn.execute("SELECT COUNT(*) FROM equiv_classes")
+        return cur.fetchone()[0]
+
+
+def load_sqlite_oracle_data(file_path: Path) -> Tuple[Dict[str, Any], sqlite3.Connection, SqliteOracleMap]:
+    """Load oracle data from sqlite database.
+
+    Args:
+        file_path: Path to sqlite oracle file.
+
+    Returns:
+        Tuple of (metadata dict, connection, oracle_map).
+        Metadata contains 'num_variables', 'num_samples', 'inputs'.
+
+    Raises:
+        NotSqliteOracleError: If the file is not a valid sqlite oracle database.
+    """
+    try:
+        conn = sqlite3.connect(file_path)
+
+        cur = conn.execute("SELECT key, value FROM metadata")
+
+        raw_meta = dict(cur.fetchall())
+
+        meta = {
+            'num_variables': raw_meta['num_variables'],
+            'num_samples': raw_meta['num_samples'],
+            'inputs': pickle.loads(raw_meta['inputs']),
+        }
+
+        return meta, conn, SqliteOracleMap(conn)
+    except sqlite3.DatabaseError as e:
+        raise NotSqliteOracleError(f"Not a valid sqlite oracle: {e}") from e
+
+
+def dump_sqlite_oracle_data(
+    file_path: Path,
+    num_variables: int,
+    num_samples: int,
+    inputs: List[List[int]],
+    oracle_map: Dict[str, List[Expr]],
+) -> None:
+    """Save oracle data to sqlite database.
+
+    Args:
+        file_path: Path to write sqlite file.
+        num_variables: Number of variables.
+        num_samples: Number of samples.
+        inputs: Input samples.
+        oracle_map: Equivalence class map.
+    """
+    if file_path.exists():
+        # Remove existing to rebuild from scratch
+        file_path.unlink()
+
+    conn = sqlite3.connect(file_path)
+    conn.execute("CREATE TABLE metadata (key TEXT PRIMARY KEY, value BLOB)")
+    conn.execute("CREATE TABLE equiv_classes (equiv_class BLOB PRIMARY KEY, members BLOB)")
+
+    conn.execute("INSERT INTO metadata VALUES (?, ?)", ('num_variables', num_variables))
+    conn.execute("INSERT INTO metadata VALUES (?, ?)", ('num_samples', num_samples))
+    conn.execute("INSERT INTO metadata VALUES (?, ?)", ('inputs', pickle.dumps(inputs)))
+
+    for k, v in oracle_map.items():
+        conn.execute("INSERT INTO equiv_classes VALUES (?, ?)",
+                     (bytes.fromhex(k), SqliteOracleMap._exprs_to_bytes(v)))
+    conn.commit()
+    conn.close()

--- a/scripts/gen_oracle.py
+++ b/scripts/gen_oracle.py
@@ -15,12 +15,12 @@ def setup_logging() -> None:
     console_handler.setFormatter(logging.Formatter('%(name)-18s - %(levelname)-8s: %(message)s'))
     logger.addHandler(console_handler)
 
-def main(num_variables: int, num_io_samples: int, library_path: Path, oracle_path: Path) -> None:
+def main(num_variables: int, num_io_samples: int, library_path: Path, oracle_path: Path, use_sqlite: bool) -> None:
     start_time = time.time()
     logger.info(f"Computing oracle for {num_variables} variables and {num_io_samples} samples. Using library at '{library_path.as_posix()}'")
     oracle = SimplificationOracle(num_variables, num_io_samples, library_path)
-    logger.info(f"Writing oracle to {oracle_path.as_posix()}")
-    oracle.dump_to_file(oracle_path)
+    logger.info(f"Writing oracle to {oracle_path.as_posix()} (format: {'sqlite' if use_sqlite else 'pickle'})")
+    oracle.dump_to_file(oracle_path, use_sqlite=use_sqlite)
     logger.info(f"Done in {round(time.time() - start_time, 2)} seconds")
 
 
@@ -31,12 +31,14 @@ if __name__ == "__main__":
     parser.add_argument("--variables", dest="num_variables", type=int, default=30, 
         help="Number of variables in a function f(x0, ..., xn). \
         Since msynth sometimes uses intermediate variables, a number of ~30 is mostly a good trade off.")
-    parser.add_argument("--samples", dest="num_io_samples", type=int, default=50, 
+    parser.add_argument("--samples", dest="num_io_samples", type=int, default=50,
         help="Number of individual output samples to determine the expression's equivalence class. \
         The smaller the number, the less accurate the results, but also the faster the computation. \
             ~ 10: fast, but less accurate \
             ~ 100: slow, way more accurate: \
             ~ 30 to 50 are good trade offs")
+    parser.add_argument("--sqlite", action="store_true",
+        help="Save oracle in sqlite format for lazy loading (faster load times)")
     args = parser.parse_args()
     setup_logging()
-    main(args.num_variables, args.num_io_samples, args.library_path, args.oracle_path)
+    main(args.num_variables, args.num_io_samples, args.library_path, args.oracle_path, args.sqlite)

--- a/tests/simplification/test_oracle.py
+++ b/tests/simplification/test_oracle.py
@@ -44,3 +44,19 @@ def test_oracle_roundtrip(tmp_path: Path) -> None:
     assert loaded.num_variables == oracle.num_variables
     assert loaded.num_samples == oracle.num_samples
     assert loaded.oracle_map.keys() == oracle.oracle_map.keys()
+
+
+def test_oracle_sqlite_roundtrip(tmp_path: Path) -> None:
+    library = write_library(tmp_path)
+    oracle = SimplificationOracle(num_variables=2, num_samples=5, library_path=library)
+    out_path = tmp_path / "oracle.db"
+    oracle.dump_to_file(out_path, use_sqlite=True)
+
+    with SimplificationOracle.load_from_file(out_path) as loaded:
+        assert loaded.num_variables == oracle.num_variables
+        assert loaded.num_samples == oracle.num_samples
+        for key in oracle.oracle_map.keys():
+            assert loaded.contains_equiv_class(key)
+            original_members = [e for e in oracle.oracle_map[key]]
+            loaded_members = [e for e in loaded.oracle_map[key]]
+            assert loaded_members == original_members


### PR DESCRIPTION
Rather than load all expressions up front (most of which will never be used), they can be loaded lazily which improves startup time AND exit time (garbage collection) significantly.

```bash
# oracle pickle
$ time ./msynth_run.py triton_smt/op_0x010_pc_update.py
PC + 0xC
./msynth_run.py triton_smt/op_0x010_pc_update.py  10.86s user 0.20s system 99% cpu 11.120 total

# oracle shelve
$ time ./msynth_run.py triton_smt/op_0x010_pc_update.py
PC + 0xC
./msynth_run.py triton_smt/op_0x010_pc_update.py  0.16s user 0.02s system 93% cpu 0.191 total
```

Although a caveat of shelves in particular is they seems to be significantly larger:
```
$ du -sh --apparent-size oracle.db
324M    oracle.db
$ du -sh --apparent-size oracle.pickle
58M     oracle.pickle
```

Currently I have it detect and load either the shelve or pickle and only save to shelve, but if being able to save to pickle is still desirable I can add back pickle saving.

I've also been experimenting with a custom binary format to allow even faster loading with more reasonable disk size, but requires quite a bit more code and is less flexible.