### PR TITLE
Fix compile_expr_to_python not memoizing subexpressions

### DIFF
--- a/tests/utils/test_expr_utils_compile.py
+++ b/tests/utils/test_expr_utils_compile.py
@@ -485,3 +485,11 @@ def test_compile_randomized_ext_ops() -> None:
         for expr in [zero_expr, sign_expr]:
             func = compile_expr_to_python(expr)
             assert func([0]) == miasm_eval(expr, [0])
+
+def test_compile_shared_subexpression_or_chain() -> None:
+    expr = ExprId("p0", 32)
+    for _ in range(25):
+        expr = ExprOp("|", expr, expr)
+    func = compile_expr_to_python(expr)
+    inputs = [0x12345678]
+    assert func(inputs) == miasm_eval(expr, inputs)


### PR DESCRIPTION
This fixes the following which crashes trying to inline subexpressions over and over:

```python
from miasm.expression.expression import ExprId, ExprOp
from msynth.simplification.simplifier import Simplifier

expr = ExprId("x", 32)

for _ in range(25):
    expr = ExprOp("|", expr, expr)

result = Simplifier("oracle.pickle").simplify(expr)

print(f"Result: {result}")
```